### PR TITLE
Fix typo in example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ class ThemeToggler extends React.Component<
           Toggle theme
         </button>
         {this.props.children}
-      </ThemeContext.Provider>
+      </ContextComposer>
     );
   }
 }


### PR DESCRIPTION
The JSX syntax highlighter still doesn't like this...there may be another typo in the code somewhere