### PR TITLE
Deprecate react-context-composer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,24 @@
-# react-context-composer
+# DEPRECATED
+
+With the advent of React's new hooks feature, this package has little value. Instead of rendering your contexts, you can use the react hook to access it in the function definition. An example:
+
+```js
+import { useContext } from 'react';
+import { ContextA, ContextB, ContextC } from './contexts';
+
+function Component() {
+  const a = useContext(ContextA);
+  const b = useContext(ContextB);
+  const c = useContext(ContextC);
+  
+  return (<...>);
+}
+```
+
+
+## react-context-composer 
 
 React 16.3 shipped a new [Context API](https://reactjs.org/docs/context.html). The API encourages composition. This utility component helps keep your code clean when your component will be rendering multiple Context Providers and Consumers.
-
-## Install
-
-```bash
-npm install --save react-context-composer
-```
 
 ## Usage
 


### PR DESCRIPTION
The motivation for this package was to deal with apps that utilized multiple contexts. The react team has fixed this syntactical issue with a better feature called [Hooks](https://reactjs.org/docs/hooks-reference.html#usecontext). 

We have decided to deprecate this package to encourage users to use hooks once it's landed. Until then, this package is still downloadable and usable. But will not be maintained with any React API changes.